### PR TITLE
This allows assets without covers to be downloaded.

### DIFF
--- a/gumroad_download.py
+++ b/gumroad_download.py
@@ -137,13 +137,16 @@ def parse_library_json(json_text):
             logging.warn('Creator name is missing with id %s for product "%s"', athing['product']['creator_id'], gri.name)
             gri.creator_name = '[id %s]' % athing['product']['creator_id']
 
-        logging.info('Found product "%s" by %s',gri.name, gri.creator_name)
+        logging.info('Found product "%s" by %s', gri.name, gri.creator_name)
         gri.thumbnail = athing['product']['thumbnail_url']
         gri.images = []
 
-        for cover in athing['product']['covers']:
-            cover_url = cover['url']
-            gri.images.append(cover_url)
+        if 'covers' in athing['product']:
+            for cover in athing['product']['covers']:
+                cover_url = cover['url']
+                gri.images.append(cover_url)
+        else:
+            logging.warn('No covers found for product "%s"', gri.name)
 
         gri.download_url = athing['purchase']['download_url']
         gri.purchase_id = athing['purchase']['id']


### PR DESCRIPTION
I was getting this error when using the script. The changes I made fixed it.

> 2024-08-08 19:41:27,530 [CRITICAL] {gumroad_download.py:59} Uncaught exception
Traceback (most recent call last):
  File "C:\Users\admin\Downloads\gumroad-download-master\gumroad_download.py", line 303, in <module>
    gumroad_items =  parse_library_json(library_json)
  File "C:\Users\admin\Downloads\gumroad-download-master\gumroad_download.py", line 144, in parse_library_json
    for cover in athing['product']['covers']:
KeyError: 'covers'